### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/patrykgawinek/gbifwebclient/security/code-scanning/1](https://github.com/patrykgawinek/gbifwebclient/security/code-scanning/1)

To fix this problem, add a `permissions` block specifying the minimum required permissions. For this workflow, the minimal required permission is read-only access to repository contents, which is needed for actions/checkout and reading the code to run tests. You should add `permissions: contents: read` either at the root of the workflow (affecting all jobs) or at the job level (just before `runs-on`). Conventionally, root-level is preferable unless jobs have differing needs.

Specifically, in `.github/workflows/node.js.yml`, add the following block after the `name` key and before the `on:` key:

```yaml
permissions:
  contents: read
```

No other changes, imports, or definitions are necessary, as this change does not affect how the workflow operates.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
