### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -10,6 +10,8 @@ name: Deploy to Firebase Hosting on merge
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/patrykgawinek/gbifwebclient/security/code-scanning/2](https://github.com/patrykgawinek/gbifwebclient/security/code-scanning/2)

To fix this problem, we should explicitly declare a `permissions` block at the job level or workflow level. Since there is only one job (`build_and_deploy`), it is simplest and most specific to place the block under that job. The minimal permission required for `repoToken: "${{ secrets.GITHUB_TOKEN }}"` used with `FirebaseExtended/action-hosting-deploy` is `contents: read`. However, to perform deployments, the action may require at least `contents: write` (see [action docs](https://github.com/FirebaseExtended/action-hosting-deploy)), but for merge-triggered deploys, often `contents: read` suffices unless you need to create commits, tags, or releases. You may need to consult action documentation or logs to confirm if more permissions are required (such as `pages: write`, `deployments: write`), but usually `contents: read` is a safe baseline.

Edit `.github/workflows/firebase-hosting-merge.yml` under the `build_and_deploy` job (on or after line 12) and add:
```yaml
permissions:
  contents: read
```
If further testing shows the action needs additional permissions (like `contents: write`), update accordingly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
